### PR TITLE
Fix/jackson CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.curityVersion>6.0.0</project.curityVersion>
-        <project.slf4jVersion>1.7.25</project.slf4jVersion>
-        <project.awssdkVersion>2.16.26</project.awssdkVersion>
+        <project.curityVersion>8.1.0</project.curityVersion>
+        <project.slf4jVersion>2.0.3</project.slf4jVersion>
+        <project.awssdkVersion>2.20.34</project.awssdkVersion>
     </properties>
 
     <build>
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <phase>process-sources</phase>
@@ -107,14 +107,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.1</version>
+            <version>2.14.2</version>
         </dependency>
 
         <!-- Test dependencies that we do not deploy -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.0</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/curity/identityserver/plugin/alarmhandler/EventsBridgeAlarmConfiguration.java
+++ b/src/main/java/io/curity/identityserver/plugin/alarmhandler/EventsBridgeAlarmConfiguration.java
@@ -19,7 +19,6 @@ package io.curity.identityserver.plugin.alarmhandler;
 import java.util.Optional;
 import se.curity.identityserver.sdk.config.Configuration;
 import se.curity.identityserver.sdk.config.OneOf;
-import se.curity.identityserver.sdk.config.annotation.DefaultBoolean;
 import se.curity.identityserver.sdk.config.annotation.DefaultString;
 import se.curity.identityserver.sdk.config.annotation.Description;
 
@@ -68,6 +67,6 @@ public interface EventsBridgeAlarmConfiguration extends Configuration {
         }
 
         @Description("EC2 instance that the Curity Identity Server is running on has been assigned an IAM Role with permissions to Events Bridge.")
-        Optional<@DefaultBoolean(false) Boolean> isEC2InstanceProfile();
+        Optional<Boolean> isEC2InstanceProfile();
     }
 }


### PR DESCRIPTION
Updates to 2.14 Jackson 2.14 version to fix the CVE.
The plugin uses JSON as a format to send to AWS via its events bridge SDK.
